### PR TITLE
Added docker and docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    build: .
+    container_name: sokora
+    restart: unless-stopped
+    volumes:
+      - ./data.db:/app/data.db
+      - ./.env:/app/.env
+

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:latest
+
+WORKDIR /app
+
+COPY package.json bun.lock tsconfig.json ./
+
+RUN bun install
+
+COPY cli ./cli
+COPY src ./src
+COPY static ./static
+
+CMD ["bun", "dev"]
+


### PR DESCRIPTION
Added this by request :D

## About
The Dockerfile cannot work by itself, due to the bot needing data.db and .env, which aren't good to pack into the image. That's the reason I included docker compose. The bot should technically auto-restart on failure (restart if stopped/crashed/killed, except if taken down)

## Usage
Pretty basic:
- If you already have the image built, just run `docker compose up` (or with `-d` (short for `--detach`` for detached)
- To build the image and run it directly, add the `--build` flag (no shortening sadly
And yeah thats it.

To take it down, just `cd` into your clone and run `docker compose down`. Easy :D

#### Hopefully this all will work smooth :crossed_fingers: 