### PR TITLE
add functional in-bot changelog viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 
 # Sokora Changelog
 
-## 0.4.0 (work in progress)
+## 0.4.0 - Heijun - Work in progress
 
 ### Added
 
-- Added the ability to import levelling data from MEE6, Tatsu, and Lurkr.
-- (WIP) Added level rewards.
-- Added the ability to upload one image to your news. (Cannot edit or remove images, nor add images from the edit modal.)
-- Added the ability to ping users and roles, link channels, and add custom timestamps to news. Discord doesn't allow this from the modal editor, so it uses a Dynamic Variables-ish syntax (Dynamic Mentions). See `/help variables` for info.
-- Added the ability to remove a user's messages when banning them. Use `/moderation ban user:@USER del:true` for this.
+- Importing levelling data from MEE6, Tatsu, and Lurkr.
+- (WIP) Level rewards.
+- Upload one image to your news. (Cannot edit or remove images, nor add images from the edit modal.)
+- Pinging users and roles, linking channels and adding custom timestamps to news. Discord doesn't allow this from the modal editor, so it uses a Dynamic Variables-ish syntax (Dynamic Mentions). See `/help variables` for info.
+- Removing a user's messages when banning them. Use `/moderation ban user:@USER del:true` for this.
+- Functional `/changelog` command (view all version logs directly from the bot).
 
 ### Changed
 
@@ -55,7 +56,7 @@
 - Fixed topgg reminders
 - Some internal fixes
 
-## 0.3.0 - 20/08/2025
+## 0.3.0 - Antei - 20/08/2025
 
 ### Added
 
@@ -119,7 +120,9 @@
 - Changelog
   - Changelog itself won't be shown in embeds anymore (it's too long). `/changelog` will show a link to this file.
 
-## 0.2.0 - 24/12/2024
+## 0.2.0 - Kaishi - 24/12/2024
+
+<!--[TODO] is this also Kaishi? i've been looking through the commit history and couldn't find a codename for 0.2, it's also called Kaishi-->
 
 ### Added
 
@@ -159,6 +162,6 @@
 - warn mentions in `/moderation warn` are now warning to be more consistent
 - Removed old markdown remnants from `/moderation slowdown`
 
-## 0.1.0 - 16/11/2024
+## 0.1.0 - Kaishi - 16/11/2024
 
-### Initial release :)
+### Initial release :D

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -1,31 +1,80 @@
 import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ClientUser,
+  ComponentType,
   ContainerBuilder,
   SlashCommandBuilder,
   TextDisplayBuilder,
   type ChatInputCommandInteraction,
 } from "discord.js";
-import { version } from "package";
 import { colorize, Sokolors } from "utils/colorGen";
 import { replace } from "utils/replace";
+import { getChangelog, getVersions } from "../utils/changelog";
+import { buttonCheck } from "embeds/errorEmbed";
 
 export const data = new SlashCommandBuilder()
   .setName("changelog")
-  .setDescription(`Sends a link to Sokora's latest version (${version}) changelog.`)
+  .setDescription("Shows Sokora's changelog.")
   .setContexts(0);
 
-export async function run(interaction: ChatInputCommandInteraction) {
-  const user = interaction.client.user;
-  const container = new ContainerBuilder()
+async function genChangelog(
+  user: ClientUser,
+  changelog: ReturnType<typeof getChangelog>,
+  list: ReturnType<typeof getVersions>,
+): Promise<ContainerBuilder> {
+  return new ContainerBuilder()
     .addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(`## Changelog for ${version}`),
       new TextDisplayBuilder().setContent(
-        "See Sokora's changelog [here](https://github.com/SokoraDesu/Sokora/blob/dev/CHANGELOG.md).",
+        `## Changelog for ${changelog.ver}${changelog.codename ? ` • *${changelog.codename}*` : ""}`,
       ),
-      new TextDisplayBuilder().setContent(`-# ${replace("(madeWith)")}`),
+      new TextDisplayBuilder().setContent(changelog.body),
+      new TextDisplayBuilder().setContent(
+        `-# Released ${changelog.date} • ${replace("(madeWith)")}`,
+      ),
+    )
+    .addActionRowComponents(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        ...list.map(v =>
+          new ButtonBuilder()
+            .setLabel(v.ver)
+            .setCustomId(v.ver)
+            .setStyle(v.minor ? ButtonStyle.Primary : ButtonStyle.Secondary)
+            .setDisabled(v.ver === changelog.ver),
+        ),
+      ),
     )
     .setAccentColor(
       await colorize({ user, avatar: user.displayAvatarURL(), hue: Sokolors.Purple }),
     );
+}
 
-  await interaction.reply({ components: [container], flags: ["Ephemeral", "IsComponentsV2"] });
+export async function run(interaction: ChatInputCommandInteraction) {
+  const user = interaction.client.user;
+  const logList = getVersions();
+  const container = await genChangelog(user, getChangelog(logList[0].ver), logList.slice(0, 5));
+
+  const reply = await interaction.reply({
+    components: [container],
+    flags: ["Ephemeral", "IsComponentsV2"],
+  });
+  const collector = reply.createMessageComponentCollector({
+    componentType: ComponentType.Button,
+    time: 120000,
+  });
+  collector.on("collect", async (i: ButtonInteraction) => {
+    if (await buttonCheck({ i, interaction, reply })) return;
+    collector.resetTimer({ time: 120000 });
+
+    const found = logList.findIndex(v => v.ver === i.customId);
+    const idx = Math.max(0, Math.min(found - 2, logList.length - 3));
+    console.log(i.customId);
+    console.log(getChangelog(i.customId));
+    return await i.update({
+      components: [await genChangelog(user, getChangelog(i.customId), logList.slice(idx, idx + 5))],
+      flags: ["IsComponentsV2"],
+    });
+  });
 }

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -1,0 +1,49 @@
+type TVer = `${number}/${number}/${number}` | "Work in progress";
+type TParsedVersion = { minor: boolean; ver: string; codename: null | string; date: TVer };
+const changelog = await Bun.file("./CHANGELOG.md").text();
+
+/**
+ * Gets the changelog of a specified Sokora version (directly from CHANGELOG.md).
+ *
+ * @param ver Version to get changelog for.
+ * @returns An object with changelog data.
+ */
+export function getChangelog(ver: string): TParsedVersion & {
+  body: string;
+} {
+  const _ = changelog.split("\n").filter(s => !s.startsWith("<!--"));
+  const i = _.findIndex(s => s.startsWith(`## ${ver}`));
+  const i2 = _.slice(i).filter(Boolean);
+  const i3 = i2.slice(1).findIndex(s => s.startsWith("## "));
+  const lines = i2.slice(0, (i3 === -1 ? i2.length - 1 : i3) + 1);
+
+  return {
+    ...parseVersion(lines[0]),
+    body: lines.slice(1).join("\n"),
+  };
+}
+
+function parseVersion(str: string): TParsedVersion {
+  const [ver, codename, date] = str.replace("## ", "").split(" - ");
+  const minor = ver.endsWith(".0");
+  if (!date) return { ver, date: codename as any, minor, codename: null };
+  return { ver, date: date as any, codename, minor };
+}
+
+/**
+ * Gets a list of all released versions.
+ *
+ * @returns An array of objects telling you the version, the date, and whether it's a minor or a patch release (SemVer-wise).
+ */
+export function getVersions(): TParsedVersion[] {
+  const res: TParsedVersion[] = [];
+
+  changelog
+    .split("\n")
+    .filter(s => s.startsWith("## "))
+    .map(s => {
+      res.push(parseVersion(s));
+    });
+
+  return res;
+}


### PR DESCRIPTION
Adds a small parser that allows to turn the contents of `CHANGELOG.md` into a browsable changelog (from `/changelog`). From said view, the Markdown text is rendered, and a button row appears at the botton showing 5 versions (changes as you move from one version to another). Also shows release date, and for minor versions it shows the codename in the header.