### PR TITLE
split changelog per categories + fixed embed footer + cv2 serverEmbed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Fixed `/moderation ban` not working on members not in the guild.
 - Fixed some minor issues with timestamps.
+- The "made with ❤️ by the Sokora team" footer in many embeds was supposed to randomize the emoji but it never did; fixed that too.
 
 ## 0.3.2 - 26/08/2025
 
@@ -156,12 +157,12 @@
 - Moderation commands
   - `/moderation clear` removed one more message than the user provided
   - `/moderation unban` errored internally (it should send an error embed) when the user didn\'t have the "Ban Members" permission
-
-### Typos
-
-- warn mentions in `/moderation warn` are now warning to be more consistent
-- Removed old markdown remnants from `/moderation slowdown`
+- Typos
+  - warn mentions in `/moderation warn` are now warning to be more consistent
+  - Removed old markdown remnants from `/moderation slowdown`
 
 ## 0.1.0 - Kaishi - 16/11/2024
 
-### Initial release :D
+### Added
+
+Initial release :D

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -6,6 +6,7 @@ import {
   ClientUser,
   ComponentType,
   ContainerBuilder,
+  SeparatorBuilder,
   SlashCommandBuilder,
   TextDisplayBuilder,
   type ChatInputCommandInteraction,
@@ -23,18 +24,35 @@ export const data = new SlashCommandBuilder()
 async function genChangelog(
   user: ClientUser,
   changelog: ReturnType<typeof getChangelog>,
+  viewing: keyof ReturnType<typeof getChangelog>["body"],
   list: ReturnType<typeof getVersions>,
 ): Promise<ContainerBuilder> {
   return new ContainerBuilder()
     .addTextDisplayComponents(
       new TextDisplayBuilder().setContent(
-        `## Changelog for ${changelog.ver}${changelog.codename ? ` • *${changelog.codename}*` : ""}`,
+        `## What's ${viewing.toLowerCase()} in ${changelog.ver}${changelog.codename ? ` • *${changelog.codename}*` : ""}`,
       ),
-      new TextDisplayBuilder().setContent(changelog.body),
-      new TextDisplayBuilder().setContent(
-        `-# Released ${changelog.date} • ${replace("(madeWith)")}`,
+      new TextDisplayBuilder().setContent(changelog.body[viewing]),
+    )
+    .addActionRowComponents(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        ...Object.keys(changelog.body).map(v =>
+          new ButtonBuilder()
+            .setLabel(v)
+            .setCustomId(v + "+" + changelog.ver)
+            .setStyle(
+              {
+                Fixed: ButtonStyle.Secondary,
+                Added: ButtonStyle.Success,
+                Removed: ButtonStyle.Danger,
+                Changed: ButtonStyle.Secondary,
+              }[v]!,
+            )
+            .setDisabled(v === viewing),
+        ),
       ),
     )
+    .addSeparatorComponents(new SeparatorBuilder().setDivider(true))
     .addActionRowComponents(
       new ActionRowBuilder<ButtonBuilder>().addComponents(
         ...list.map(v =>
@@ -46,15 +64,38 @@ async function genChangelog(
         ),
       ),
     )
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `-# Use the buttons above to view categories (like what we added or changed) or view other versions.\n-# Released ${changelog.date} • ${replace("(madeWith)")}`,
+      ),
+    )
     .setAccentColor(
       await colorize({ user, avatar: user.displayAvatarURL(), hue: Sokolors.Purple }),
     );
 }
 
+function getDefaultCategoryToView(
+  changelog: ReturnType<typeof getChangelog>,
+): keyof ReturnType<typeof getChangelog>["body"] {
+  return changelog.body["Added"]
+    ? "Added"
+    : changelog.body["Changed"]
+      ? "Changed"
+      : changelog.body["Fixed"]
+        ? "Fixed"
+        : "Removed";
+}
+
 export async function run(interaction: ChatInputCommandInteraction) {
   const user = interaction.client.user;
   const logList = getVersions();
-  const container = await genChangelog(user, getChangelog(logList[0].ver), logList.slice(0, 5));
+  const changelog = getChangelog(logList[0].ver);
+  const container = await genChangelog(
+    user,
+    changelog,
+    getDefaultCategoryToView(changelog),
+    logList.slice(0, 5),
+  );
 
   const reply = await interaction.reply({
     components: [container],
@@ -68,12 +109,24 @@ export async function run(interaction: ChatInputCommandInteraction) {
     if (await buttonCheck({ i, interaction, reply })) return;
     collector.resetTimer({ time: 120000 });
 
-    const found = logList.findIndex(v => v.ver === i.customId);
+    const split = i.customId.replace("-", "").split("+");
+    const newVer = ["Added", "Changed", "Fixed", "Removed"].some(s =>
+      i.customId.startsWith(s + "+"),
+    )
+      ? split[1]
+      : split[0];
+    const found = logList.findIndex(v => v.ver === newVer);
     const idx = Math.max(0, Math.min(found - 2, logList.length - 3));
-    console.log(i.customId);
-    console.log(getChangelog(i.customId));
+    const log = getChangelog(newVer);
     return await i.update({
-      components: [await genChangelog(user, getChangelog(i.customId), logList.slice(idx, idx + 5))],
+      components: [
+        await genChangelog(
+          user,
+          log,
+          split[1] ? (split[0] as any) : getDefaultCategoryToView(log),
+          logList.slice(idx, idx + 5).filter(v => v !== undefined),
+        ),
+      ],
       flags: ["IsComponentsV2"],
     });
   });

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8,5 +8,5 @@ export const data = new SlashCommandBuilder()
 
 export async function run(interaction: ChatInputCommandInteraction) {
   const embed = await serverEmbed({ guild: interaction.guild!, roles: true });
-  await interaction.reply({ embeds: [embed] });
+  await interaction.reply({ components: [embed], flags: "IsComponentsV2" });
 }

--- a/src/commands/serverboard.ts
+++ b/src/commands/serverboard.ts
@@ -62,7 +62,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
   const argPage = interaction.options.getNumber("page") as number;
   let page = (argPage - 1 <= 0 ? 0 : argPage - 1 > pages ? pages - 1 : argPage - 1) || 0;
 
-  async function getEmbed() {
+  async function getContainer() {
     return await serverEmbed({
       guild: guildList[page].guild,
       invite: {
@@ -87,8 +87,8 @@ export async function run(interaction: ChatInputCommandInteraction) {
   );
 
   const reply = await interaction.reply({
-    embeds: [await getEmbed()],
-    components: pages > 1 ? [row] : [],
+    components: [await getContainer(), pages > 1 ? row : undefined].filter(v => v !== undefined),
+    flags: "IsComponentsV2",
   });
 
   if (pages == 1) return;
@@ -107,7 +107,7 @@ export async function run(interaction: ChatInputCommandInteraction) {
         break;
     }
 
-    await i.update({ embeds: [await getEmbed()], components: [row] });
+    await i.update({ components: [await getContainer(), row] });
   });
 
   collector.on("end", async () => {

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -1,5 +1,8 @@
 type TVer = `${number}/${number}/${number}` | "Work in progress";
 type TParsedVersion = { minor: boolean; ver: string; codename: null | string; date: TVer };
+type TParsedChangelog = TParsedVersion & {
+  body: Record<"Fixed" | "Added" | "Removed" | "Changed", string>;
+};
 const changelog = await Bun.file("./CHANGELOG.md").text();
 
 /**
@@ -8,18 +11,29 @@ const changelog = await Bun.file("./CHANGELOG.md").text();
  * @param ver Version to get changelog for.
  * @returns An object with changelog data.
  */
-export function getChangelog(ver: string): TParsedVersion & {
-  body: string;
-} {
+export function getChangelog(ver: string): TParsedChangelog {
   const _ = changelog.split("\n").filter(s => !s.startsWith("<!--"));
   const i = _.findIndex(s => s.startsWith(`## ${ver}`));
-  const i2 = _.slice(i).filter(Boolean);
+  const i2 = _.slice(i).filter(s => s.trim() !== "");
   const i3 = i2.slice(1).findIndex(s => s.startsWith("## "));
-  const lines = i2.slice(0, (i3 === -1 ? i2.length - 1 : i3) + 1);
+  const lines = i2.slice(0, (i3 === -1 ? i2.length : i3 + 1) + 1);
+  const base = lines.slice(1);
+  const categories = base.filter(s => s.startsWith("### ")).map(s => s.replace("### ", ""));
+  const entries: [keyof TParsedChangelog["body"], string][] = [];
+  categories.forEach(cat => {
+    const i = base.findIndex(s => s.startsWith("### " + cat));
+    const i2 = base.slice(i + 1).findIndex(s => s.startsWith("### "));
+    const newBase = base
+      .slice(i, i2 === -1 ? base.length : i + 1 + i2)
+      .slice(1)
+      .filter(s => !s.startsWith("## ")) // patch
+      .join("\n");
+    if (newBase !== "") entries.push([cat as keyof TParsedChangelog["body"], newBase]);
+  });
 
   return {
     ...parseVersion(lines[0]),
-    body: lines.slice(1).join("\n"),
+    body: Object.fromEntries(entries) as TParsedChangelog["body"],
   };
 }
 

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -91,7 +91,7 @@ export async function serverEmbed(options: Options): Promise<ContainerBuilder> {
           : `${sortedRoles
               .slice(0, 3)
               .map(role => mention(role[0], "ROLE"))
-              .join(" • ")}${rolesLength > 5 ? ` and **${rolesLength - 3}** more` : ""}`
+              .join(" • ")}${rolesLength > 3 ? ` and **${rolesLength - 3}** more` : ""}`
       }`,
     );
 

--- a/src/utils/embeds/serverEmbed.ts
+++ b/src/utils/embeds/serverEmbed.ts
@@ -1,9 +1,14 @@
 import { resetSetting } from "database/settings";
 import {
+  ContainerBuilder,
   EmbedBuilder,
   NewsChannel,
+  SectionBuilder,
+  SeparatorBuilder,
   StageChannel,
   TextChannel,
+  TextDisplayBuilder,
+  ThumbnailBuilder,
   VoiceChannel,
   type Guild,
 } from "discord.js";
@@ -26,11 +31,11 @@ type Options = {
 };
 
 /**
- * Sends an embed containing information about the guild.
+ * Gives you a CONTAINER containing information about the guild.
  * @param options Options of the embed.
- * @returns Embed that contains the guild info.
+ * @returns Container that contains the guild info.
  */
-export async function serverEmbed(options: Options) {
+export async function serverEmbed(options: Options): Promise<ContainerBuilder> {
   const { page, pages, guild, invite } = options;
   const { premiumTier: boostTier, premiumSubscriptionCount: boostCount } = guild;
   const boosters = guild.members.cache.filter(member => member.premiumSince);
@@ -54,7 +59,7 @@ export async function serverEmbed(options: Options) {
   const generalValues = [
     `Owned by **${owner.user.displayName}**`,
     `Created on **${mention(guild.createdAt.valueOf(), "DEFAULT_TIMESTAMP")}**`,
-  ];
+  ].join("\n");
 
   const vl = guild.verificationLevel;
   const nsfw = guild.nsfwLevel;
@@ -84,36 +89,35 @@ export async function serverEmbed(options: Options) {
         roles.size == 1
           ? "*None*"
           : `${sortedRoles
-              .slice(0, 5)
+              .slice(0, 3)
               .map(role => mention(role[0], "ROLE"))
-              .join(" • ")}${rolesLength > 5 ? ` and **${rolesLength - 5}** more` : ""}`
+              .join(" • ")}${rolesLength > 5 ? ` and **${rolesLength - 3}** more` : ""}`
       }`,
     );
 
   const dot = dotCheck({ string: icon, doubleSpace: true });
-  const embed = new EmbedBuilder()
-    .setAuthor({ name: `${pages ? `#${page}  •  ` : dot}${guild.name}`, iconURL: icon })
-    .setDescription(guild.description ? `> ${guild.description}` : null)
-    .setFields(
-      {
-        name: "📃 • General",
-        value: generalValues.join("\n"),
-        inline: true,
-      },
-      {
-        name: "🛡 • Safety setup",
-        value: safetyValues.join("\n"),
-        inline: true,
-      },
-      {
-        name: "📈 • Stats",
-        value: statValues.join("\n"),
-      },
-    )
-    .setFooter({
-      text: `${pages && pages > 1 ? `Page ${page} of ${pages} • ` : ""}Server ID: ${guild.id}`,
-    })
-    .setColor(await colorize({ avatar: icon, hue: Sokolors.Blue }));
+  const container = new ContainerBuilder();
+
+  const start = new TextDisplayBuilder().setContent(
+    [`## ${guild.name}`, generalValues, safetyValues.join(" • ")].join("\n"),
+  );
+
+  icon
+    ? container.addSectionComponents(
+        new SectionBuilder()
+          .addTextDisplayComponents(start)
+          .setThumbnailAccessory(new ThumbnailBuilder().setURL(icon)),
+      )
+    : container.addTextDisplayComponents(start);
+
+  container.addSeparatorComponents(new SeparatorBuilder().setDivider(true));
+
+  if (guild.description)
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(`> ${guild.description}`),
+    );
+
+  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(statValues.join("\n")));
 
   if (invite?.show) {
     async function noPerms(channel?: NewsChannel | TextChannel | StageChannel | VoiceChannel) {
@@ -143,7 +147,7 @@ export async function serverEmbed(options: Options) {
         },
       });
 
-      return embed;
+      return container;
     }
 
     const clientMember = await safeMember(guild, client);
@@ -171,7 +175,7 @@ export async function serverEmbed(options: Options) {
         ? possibleInviteChannel
         : guild.rulesChannel;
 
-    if (!inviteChannel) return embed;
+    if (!inviteChannel) return container;
     if (!inviteChannel.permissionsFor(client)?.has("CreateInstantInvite"))
       return noPerms(inviteChannel);
 
@@ -179,11 +183,20 @@ export async function serverEmbed(options: Options) {
       ? previousInvite.url
       : await inviteChannel.createInvite({ maxAge: 0, reason: "Serverboard invite" });
 
-    embed.addFields({
-      name: "🚪 • Join in!",
-      value: `This server allows you to join from here! ${inviteUrl}`,
-    });
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `🚪 • This server allows you to join from here! ${inviteUrl}`,
+      ),
+    );
   }
 
-  return embed;
+  container
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `-# ${pages && pages > 1 ? `Page ${page} of ${pages} • ` : ""}Server ID: ${guild.id}`,
+      ),
+    )
+    .setAccentColor(await colorize({ avatar: icon, hue: Sokolors.Blue }));
+
+  return container;
 }

--- a/src/utils/replace.ts
+++ b/src/utils/replace.ts
@@ -4,22 +4,21 @@ import { randomize } from "./randomize";
 import { safeMember } from "./safeThings";
 import type { Replacements } from "./types";
 
-// ok the fact that this is here is an issue since it doesn't actually randomize at all...
-let emojis = ["💖", "💝", "💓", "💗", "💘", "💟", "💕", "💞"];
-if (Math.round(Math.random() * 100) <= 5) emojis = ["⌨️", "💻", "🖥️"];
-
-export const replacements = [
-  { text: "(madeWith)", replacement: `Made with ${randomize(emojis)} by the Sokora team` },
-  { text: "(leftArrow)", replacement: "1298708251256291379" },
-  { text: "(rightArrow)", replacement: "1298708281493160029" },
-  { text: "(discord)", replacement: "1266797021126459423" },
-];
+const emojis =
+  Math.round(Math.random() * 100) <= 5
+    ? ["⌨️", "💻", "🖥️"]
+    : ["💖", "💝", "💓", "💗", "💘", "💟", "💕", "💞"];
 
 export function replace(
   text: string,
   replaceText?: { text: string; replacement: string | number }[],
 ) {
-  for (const mention of replaceText ?? replacements)
+  for (const mention of replaceText ?? [
+    { text: "(madeWith)", replacement: `Made with ${randomize(emojis)} by the Sokora team` },
+    { text: "(leftArrow)", replacement: "1298708251256291379" },
+    { text: "(rightArrow)", replacement: "1298708281493160029" },
+    { text: "(discord)", replacement: "1266797021126459423" },
+  ])
     if (text.includes(mention.text))
       text = text.replaceAll(mention.text, mention.replacement.toString());
 


### PR DESCRIPTION
- The "Made with (emoji) by the Sokora team" supposedly randomized the emoji, but it never did. Now it does.
- Now `/changelog` entries are split per categories, and there's a button to view each category (Added, Removed, Fixed, etc...).
- Now serverEmbed is a CV2 container. Looks good :)