### PR TITLE
[Enhancement] Added automated docker image building for production!

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=short
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 env:
   REGISTRY: ghcr.io
@@ -25,7 +26,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker
         id: meta

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,15 @@
 services:
-  app:
+  sokora:
     build: .
     container_name: sokora
+    restart: unless-stopped
+    volumes:
+      - ./data.db:/app/data.db
+      - ./.env:/app/.env
+
+  sokora-prod:
+    image: ghcr.io/sokoradesu/sokora:main
+    container_name: sokora-prod
     restart: unless-stopped
     volumes:
       - ./data.db:/app/data.db


### PR DESCRIPTION
## Why
Hey team,
as discussed before, there should be pre-built docker images of sokora available, which would make it much more easier to deploy!

## How this works
This pr includes a workflow. This workflow is triggered on every commit to main branch, and automatically builds and pushes the image to github's image repository (in this case `ghcr.io/sokoradesu/sokora:main`). There is no manual triggering required, all is automated. If you add more branches, it technically is supposed to push to `ghcr.io/sokoradesu/sokora:<branch-name>`.
As requested, I also enabled builds for dev!

## What's required?
Nothing! This workflow has all permissions defined, meaning it generates its own access token. 