### PR TITLE
[fix] RPS using wrong name when playing with a bot

### DIFF
--- a/src/commands/games/rps.ts
+++ b/src/commands/games/rps.ts
@@ -138,7 +138,7 @@ export async function run(
                 0: "## **It’s a tie!**",
                 1: `## **${user.displayName}**, you win!`,
                 2: opponent.bot
-                  ? `## **Sokora** wins!`
+                  ? `## **${opponent.displayName}** wins!`
                   : `## **${opponent.displayName}**, you win!`,
               }[winner],
             ].join("\n"),


### PR DESCRIPTION
Reported on support threat 1534770087196754031