### PR TITLE
[fix] safeAlertChannel + Canary's commit dump >

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -124,7 +124,8 @@ const yellAtEveryoneThatCanaryUpdated = async (): Promise<void> => {
       },
     },
   );
-  const log = (await response.json()) as GHCommit[];
+  const _log = (await response.json()) as GHCommit[];
+  const log = _log.filter(c => !c.commit.message.startsWith("Merge pull request"));
   const hasTooManyCommits = log.length > 6;
   const dump = log
     .slice(0, 6)

--- a/src/utils/safeThings.ts
+++ b/src/utils/safeThings.ts
@@ -1,25 +1,25 @@
 import { getSetting } from "database/settings";
-import {
-  ChannelType,
-  type DMChannel,
-  type AnySelectMenuInteraction,
-  type BaseFetchOptions,
-  type ButtonInteraction,
-  type Channel,
-  type ChatInputCommandInteraction,
-  type Client,
-  type Collection,
-  type Guild,
-  type GuildMember,
-  type InteractionEditReplyOptions,
-  type InteractionReplyOptions,
-  type InteractionResponse,
-  type Message,
-  type MessagePayload,
-  type ModalSubmitInteraction,
-  type Role,
-  type TextChannel,
-  type User,
+import type {
+  DMChannel,
+  AnySelectMenuInteraction,
+  BaseFetchOptions,
+  ButtonInteraction,
+  Channel,
+  ChatInputCommandInteraction,
+  Client,
+  Collection,
+  Guild,
+  GuildMember,
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+  InteractionResponse,
+  Message,
+  MessagePayload,
+  ModalSubmitInteraction,
+  Role,
+  TextChannel,
+  User,
+  NewsChannel,
 } from "discord.js";
 
 /**
@@ -154,19 +154,27 @@ export async function safeAlertChannel(guild: Guild, shouldDmOwner?: false): Pro
 export async function safeAlertChannel(
   guild: Guild,
   shouldDmOwner?: boolean,
-): Promise<DMChannel | TextChannel> {
+): Promise<DMChannel | NewsChannel | TextChannel> {
   const me = guild.members.me;
   if (!me) throw new Error("how??? this shouldn’t happen…");
 
   const logChannelId = await getSetting(guild.id, "moderation", "channel");
-  const logChannel = logChannelId ? await guild.channels.fetch(logChannelId) : null;
+  const _logChannel = logChannelId ? await guild.channels.fetch(logChannelId) : null;
+  const logChannel =
+    _logChannel &&
+    _logChannel.isTextBased() &&
+    !_logChannel.isThread() &&
+    _logChannel.isSendable() &&
+    !_logChannel.isVoiceBased()
+      ? _logChannel
+      : null;
 
-  const channel =
-    (logChannel?.type === ChannelType.GuildText ? logChannel : null) ??
+  const channel: NewsChannel | DMChannel | TextChannel | undefined =
+    logChannel ??
     guild.systemChannel ??
     (shouldDmOwner ? await (await guild.fetchOwner()).user.createDM() : null) ??
     guild.channels.cache
-      .filter(c => c.type === ChannelType.GuildText)
+      .filter(c => c.isTextBased() && !c.isThread() && c.isSendable() && !c.isVoiceBased())
       .filter(c => c.permissionsFor(me).has("SendMessages"))
       .sort((a, b) => a.position - b.position)
       .first();


### PR DESCRIPTION
[fix] fix safeAlertChannel only recognizing text channels and not news channels, now it does

[fix] fix Canary treating Merge commits as regular commits; they should be excluded as they provide no value and make the msg longer